### PR TITLE
feat: remove hard user lists in launcher

### DIFF
--- a/src/main/java/com/socialmediaraiser/twitterbot/PersonalAnalyzerLauncher.java
+++ b/src/main/java/com/socialmediaraiser/twitterbot/PersonalAnalyzerLauncher.java
@@ -1,7 +1,12 @@
 package com.socialmediaraiser.twitterbot;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.socialmediaraiser.twitter.TwitterClient;
 import com.socialmediaraiser.twitterbot.impl.PersonalAnalyzerBot;
+import com.socialmediaraiser.twitterbot.properties.GoogleCredentials;
 import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
 import lombok.CustomLog;
 
 @CustomLog
@@ -22,15 +27,21 @@ public class PersonalAnalyzerLauncher {
         PersonalAnalyzerBot bot         = new PersonalAnalyzerBot(userName, tweetArchivePath);
         bot.launch(includeFollowers, includeFollowings, onlyFollowBackFollowers);
       } else {
-        String[] toUnfollow = {
-            "DzzzLife","No_nam7","yassbdr","basicallyazz","LaurenceDudek","amyna133","Mel_inna91","Lauryne_Bln","FettyB7","DZ_3333","Bearmaamaa","hogwallifrey","cndsofyan","lasyn_","salmozorus","dy_nael","n__chn","rasha_rashouu","lucakows","x6testy","Moha00213","teamsuspens","_JalanSabar","tounsi_sf78","Laauryn_A","Stv_Barksdale","OceaneLovely","Youssouf__","KellyJennifer23","NoRatedTho","lspc__","bdjbt_","MaryamSabour12","213xm30","Jalilaouicmoi","l6ndy","aaron_is_bless","iliesElLoco","camilia953","ClaireNouria","PocahontasInes","Silia_Wind","A_to_the_ssia","Dylou003","imnlazone","unebinks","Algeriiennne92","AminLocoLoco","wanhedaryl","mayiswift","anissaatc","myanonyme","__kwssif","blackie9270","Sam__N_","Bilouu135_","nvss45","UnBaron_","khseiaram","anahyame","gmsandrea","sunnami31","emilieeesan","dz_srh93","Loubna_213","Benzaldo_","Vi14_","Le_Khal_","amiraaf13","AbdouSak10","tjrs_cool","mazigova","__iamnouu__","helina_ahmd","CallMequeenBieb","FerTayeb","Sahbi_Egrs","Sosofia06","maaaaissaa","etherealMSCL","KajolYuuss","Yasmine0804","joaaanneeeee","heavenwithxu","ImaneKns","linaaccessiblee","Fteh28","melkss_","charlotteevd","Solenend","KryksCdm","Nordinebkff","habibgon","mfdxbv","Imane_Kcm","ganguek_","ed_slr","coralieglb","tdlsj","catsaretrash","ChadiasarahC","alistf_","Simisco_","RaheemSterlings","LironaBerisha","alikamaty","TheNayrod","BilelMnasri","Lapegreloveya","khadyybdj","Maayssou","vucko_nina","SimoesLeaaa","Mkcnsk","isauremrcier","Messanee_","_mehmeeet","m_ineees","Valen8616","cikldn","Adriii_Wtf","camikazz__","mamimarone","n_cherryy","40_thieves_","pamplemous57","1Gars_O_Soleil2","nawslarif","krm_insaf","Faayda_Abdillah","Hffddaa","_kingluqmvn","nissa156","Unassumed_","RimeSahbi","OhKila","drissleretour","Catherineee_bhm","fendabeaute","Lulu97two","noodlejd","Kahina019","___azhr","SabinaLodbrok","fayce_b","kamso2times","t2712_iman","Khdjilli","fatkfih","leahhspp","kenza2122","yooba_ccxxi","simonagnoletti","Amandouche","Nono_1704","Offlaisse310_","TayebKospa","kanieloutis____","AminaHassen12","M_AZ93","chenis95","broly_210","Win__mood","Andily_Ibra","_Dalinaa","FrenchieAC","FabAdou","nekomamushi971","elbatataa","nwll_i","YC_945","turquirem","YSerena_","_xb2x6___","Celia_Tvbti","SecouToure","Letrendsetter","SaraLeenHayder","Mouradson","Flow91220","blaugrana_29","Luffy_Affranchi","mohamed_elhajj","Irfane_Clement","DadouDads","olivialiyung","Lillustre_Dz","Asiorak","NaelABC","NC_69_","GiuseppeParavi1","Sarah_Bcf","One4Dz","bonbouaz","Assia35583911","mohamedmoh59","shmnubia","rk_Ngadi","InesInesz","julien_Gres"
-        };
-        String[] whiteList = {"mohamedmoh59","NC_69_","DadouDads","fayce_b", "InesInesz", "caroletonneau", "KayiTurk_fr", "Asiorak", "Sarah_Bcf", "vivi83032363"
-            , "Gabriel_Bleron", "NaelABC", "Ciudadana93", "Irfane_Clement", "OneblueTeam", "Luffy_Affranchi", "silversilvery",
-                              "abdelhvmid", "souf_belkadi", "GiuseppeParavi1", "Riad7ben", "YSerena_", "Celia_Tvbti", "sombrenuance",
-                              "salmaechouay", "VictorLefranc", "julien_Gres", "rk_Ngadi", "FrenchieAC", "OtmanBsh", "sof1aninho",
-                              "SaraLeenHayder", "Mouradson", "OphelieEdb", "Naouffel","1Gars_O_Soleil2"};
-        PersonalAnalyzerBot bot              = new PersonalAnalyzerBot(userName);
+
+        URL toUnfollowUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource("to-unfollow.json");
+        if(toUnfollowUrl==null){
+          LOGGER.severe("to-unfollow.json file not found in src/main/resources");
+          return;
+        }
+        String[] toUnfollow = TwitterClient.OBJECT_MAPPER.readValue(toUnfollowUrl, new TypeReference<Map<String,String[]>>() {}).get("users");
+
+        URL whiteListUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource("white-list.json");
+        if(whiteListUrl==null){
+          LOGGER.severe("white-list.json file not found in src/main/resources");
+        }
+        String[] whiteList = TwitterClient.OBJECT_MAPPER.readValue(whiteListUrl, new TypeReference<Map<String,String[]>>() {}).get("users");
+
+        PersonalAnalyzerBot   bot       = new PersonalAnalyzerBot(userName);
         bot.unfollow(toUnfollow, whiteList);
       }
     }

--- a/src/main/java/com/socialmediaraiser/twitterbot/PersonalAnalyzerLauncher.java
+++ b/src/main/java/com/socialmediaraiser/twitterbot/PersonalAnalyzerLauncher.java
@@ -27,22 +27,10 @@ public class PersonalAnalyzerLauncher {
         PersonalAnalyzerBot bot         = new PersonalAnalyzerBot(userName, tweetArchivePath);
         bot.launch(includeFollowers, includeFollowings, onlyFollowBackFollowers);
       } else {
-
-        URL toUnfollowUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource("to-unfollow.json");
-        if(toUnfollowUrl==null){
-          LOGGER.severe("to-unfollow.json file not found in src/main/resources");
-          return;
-        }
-        String[] toUnfollow = TwitterClient.OBJECT_MAPPER.readValue(toUnfollowUrl, new TypeReference<Map<String,String[]>>() {}).get("users");
-
-        URL whiteListUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource("white-list.json");
-        if(whiteListUrl==null){
-          LOGGER.severe("white-list.json file not found in src/main/resources");
-        }
-        String[] whiteList = TwitterClient.OBJECT_MAPPER.readValue(whiteListUrl, new TypeReference<Map<String,String[]>>() {}).get("users");
-
         PersonalAnalyzerBot   bot       = new PersonalAnalyzerBot(userName);
-        bot.unfollow(toUnfollow, whiteList);
+        URL toUnfollowUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource("to-unfollow.json");
+        URL whiteListUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource("white-list.json");
+        bot.unfollow(bot.getUsersFromJson(toUnfollowUrl), bot.getUsersFromJson(whiteListUrl));
       }
     }
   }

--- a/src/main/java/com/socialmediaraiser/twitterbot/PersonalAnalyzerLauncher.java
+++ b/src/main/java/com/socialmediaraiser/twitterbot/PersonalAnalyzerLauncher.java
@@ -27,9 +27,12 @@ public class PersonalAnalyzerLauncher {
         PersonalAnalyzerBot bot         = new PersonalAnalyzerBot(userName, tweetArchivePath);
         bot.launch(includeFollowers, includeFollowings, onlyFollowBackFollowers);
       } else {
+        if (args.length < 3) LOGGER.severe(() -> "missing arguments");
+        String toUnfollowPath         = args[2];
+        String whiteListPath          = args[3];
         PersonalAnalyzerBot   bot       = new PersonalAnalyzerBot(userName);
-        URL toUnfollowUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource("to-unfollow.json");
-        URL whiteListUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource("white-list.json");
+        URL toUnfollowUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource(toUnfollowPath);
+        URL whiteListUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource(whiteListPath);
         bot.unfollow(bot.getUsersFromJson(toUnfollowUrl), bot.getUsersFromJson(whiteListUrl));
       }
     }

--- a/src/main/java/com/socialmediaraiser/twitterbot/PersonalAnalyzerLauncher.java
+++ b/src/main/java/com/socialmediaraiser/twitterbot/PersonalAnalyzerLauncher.java
@@ -28,11 +28,9 @@ public class PersonalAnalyzerLauncher {
         bot.launch(includeFollowers, includeFollowings, onlyFollowBackFollowers);
       } else {
         if (args.length < 3) LOGGER.severe(() -> "missing arguments");
-        String toUnfollowPath         = args[2];
-        String whiteListPath          = args[3];
         PersonalAnalyzerBot   bot       = new PersonalAnalyzerBot(userName);
-        URL toUnfollowUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource(toUnfollowPath);
-        URL whiteListUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource(whiteListPath);
+        URL toUnfollowUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource(args[2]);
+        URL whiteListUrl = PersonalAnalyzerLauncher.class.getClassLoader().getResource(args[3]);
         bot.unfollow(bot.getUsersFromJson(toUnfollowUrl), bot.getUsersFromJson(whiteListUrl));
       }
     }

--- a/src/main/java/com/socialmediaraiser/twitterbot/impl/PersonalAnalyzerBot.java
+++ b/src/main/java/com/socialmediaraiser/twitterbot/impl/PersonalAnalyzerBot.java
@@ -1,4 +1,5 @@
 package com.socialmediaraiser.twitterbot.impl;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.socialmediaraiser.twitter.TwitterClient;
 import com.socialmediaraiser.twitter.dto.user.IUser;
@@ -13,6 +14,7 @@ import io.vavr.collection.Map;
 import io.vavr.collection.Set;
 import io.vavr.collection.Stream;
 import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -168,5 +170,18 @@ public class PersonalAnalyzerBot {
       }
     }
     LOGGER.info(nbUnfollows + " users unfollowed with success !");
+  }
+
+  public String[] getUsersFromJson(URL fileUrl){
+    if(fileUrl==null){
+      LOGGER.severe("file not found in src/main/resources");
+      return new String[]{};
+    }
+    try {
+      return TwitterClient.OBJECT_MAPPER.readValue(fileUrl, new TypeReference<java.util.Map<String,String[]>>() {}).get("users");
+    } catch (IOException e) {
+      LOGGER.severe(e.getMessage());
+      return new String[]{};
+    }
   }
 }


### PR DESCRIPTION
Related to : https://github.com/redouane59/twitter-personal-analyzer-bot/issues/12

- removing the string list from the launcher class
- using json files to store this information